### PR TITLE
Update pathRegex for the zaken & rollen notification endpoins

### DIFF
--- a/Installation/installation.json
+++ b/Installation/installation.json
@@ -70,7 +70,10 @@
     "schemas": [
       {
         "reference": "https://kissdevelopment.commonground.nu/notification.schema.json",
-        "path": "kiss/notifications",
+        "path": [
+          "kiss",
+          "notifications"
+        ],
         "pathRegex": "^kiss/notifications$",
         "version": "0.0.4",
         "methods": [
@@ -83,7 +86,10 @@
       },
       {
         "reference": "https://kissdevelopment.commonground.nu/notification.schema.json",
-        "path": "kiss/notifications-rollen",
+        "path": [
+          "kiss",
+          "notifications-rollen"
+        ],
         "title": "notification rollen",
         "$id": "https://kissdevelopment.commonground.nu/EntityEndpoint/notification.rol.endpoint.json",
         "pathRegex": "^kiss/notifications-rollen$",

--- a/Installation/installation.json
+++ b/Installation/installation.json
@@ -71,7 +71,8 @@
       {
         "reference": "https://kissdevelopment.commonground.nu/notification.schema.json",
         "path": "kiss/notifications",
-        "version": "0.0.3",
+        "pathRegex": "^kiss/notifications$",
+        "version": "0.0.4",
         "methods": [
           "POST",
           "GET"
@@ -85,7 +86,8 @@
         "path": "kiss/notifications-rollen",
         "title": "notification rollen",
         "$id": "https://kissdevelopment.commonground.nu/EntityEndpoint/notification.rol.endpoint.json",
-        "version": "0.0.1",
+        "pathRegex": "^kiss/notifications-rollen$",
+        "version": "0.0.2",
         "methods": [
           "POST",
           "GET"


### PR DESCRIPTION
To prevent kiss/notifications/?(09az)? endpoint from being found when searching for kiss/notifications-rollen